### PR TITLE
Expand the user path in outFile when writing out to the default ~/.pydrivewirerc

### DIFF
--- a/dwcommand.py
+++ b/dwcommand.py
@@ -755,7 +755,7 @@ class DWParser:
         outFile = data
         if not outFile:
             outFile = self.server.args.config
-        with open(outFile, 'w') as f:
+        with open(os.path.expanduser(outFile), 'w') as f:
             f.write('\n'.join(out))
         return "Config Saved to: %s" % outFile
 


### PR DESCRIPTION
This fixes issue #6 using `os.path.expanduser()`. I have only tested this on a Mac but did test with a an alternate config file passed using -C when starting the repl that did not have ~ in it and it worked in both cases.