### PR TITLE
Update print() calls to follow python 3 syntax

### DIFF
--- a/test/dwclient.py
+++ b/test/dwclient.py
@@ -23,13 +23,13 @@ def openChannel(s, channel):
    data += SS_Open
    s.write(data)
    if debug:
-      print "channel %s open" % channel
+      print("channel %s open" % channel)
    channel_open = True
 
 def closeChannel(s, channel):
    # close
    if debug:
-      print "closing channel: %s" % channel
+      print("closing channel: %s" % channel)
    data = OP_SERSETSTAT
    data += chr(channel)
    data += SS_Close
@@ -45,7 +45,7 @@ def getStatus(s, channel):
    s.write(OP_SERREAD)
    r = [ord(c) for c in s.read(2)]
    if debug:
-       print "channel status: %s" % r
+       print("channel status: %s" % r)
    return r
 
 def writeChannel(s, channel, data):
@@ -56,7 +56,7 @@ def writeChannel(s, channel, data):
       dd += c
       s.write(dd)
    if debug:
-      print "write: ch=%d %s" % (channel, data)
+      print("write: ch=%d %s" % (channel, data))
 
 def readChannel(s, channel, wait=False):
    out=""
@@ -85,7 +85,7 @@ s.debug = True
 s.connect()
 channel = 2
 while True:
-   print "dwclient> ",
+   print("dwclient> ", end='')
    command = raw_input()
    if command.startswith('quit'):
       break
@@ -99,7 +99,7 @@ while True:
        openChannel(s, channel)
    getStatus(s, channel)
    writeChannel(s, channel, command+'\r')
-   print readChannel(s, channel, True)
+   print(readChannel(s, channel, True))
    if not channel_open:
        closeChannel(s, channel)
 closeChannel(s, channel)

--- a/test/dwdisktester.py
+++ b/test/dwdisktester.py
@@ -15,16 +15,16 @@ def worker(cs):
       while True:
          data = cs.recv(192)
          dl = len(data)
-         print dl
+         print(dl)
          if dl>0:
             written=0
             while written<dl:
                written +=cs.send(data[written:])
          else:
-            print "Connection dropped."
+            print("Connection dropped.")
             break
    finally:
-      print "Listening again..."
+      print("Listening again...")
 
 if len(sys.argv) < 2:
    exit(1)
@@ -38,14 +38,14 @@ if listen:
 if True:
    if listen:
       (cs, addr) = s.accept()
-      print "Accepted connection: %s" % str(addr)
+      print("Accepted connection: %s" % str(addr))
    else:
       #addr = "172.16.1.89"
       #addr = "192.168.4.1"
       addr = '127.0.0.1'
       port = 65504
       cs = socket.create_connection((addr, port))
-      print "connection to : %s:%s" % (addr,port)
+      print("connection to : %s:%s" % (addr,port))
 
    print("s")
    cs.send(OP_DWINIT)
@@ -55,7 +55,7 @@ if True:
    assert(ord(data) == 0xff)
    disk = 0
    for fileName in sys.argv[1:]:
-      print ("Checking: %s" % fileName)
+      print("Checking: %s" % fileName)
       f = open(fileName)
       rc = E_OK
       lsn = 0
@@ -80,7 +80,7 @@ if True:
          print("OP_READEX lsn %d len %d %d" % (lsn, len(data), rc))
          #msg = "%d ..." % lsn
          #msg+'\b'*len(msg),
-         #print ".",
+         #print(".", end='')
          lsn += 1
       
       print("\nCompared %d sectors rc %d" % (lsn, rc))

--- a/test/dwnamedobjtester.py
+++ b/test/dwnamedobjtester.py
@@ -19,7 +19,7 @@ s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 addr = '127.0.0.1'
 port = 65504
 cs = socket.create_connection((addr, port))
-print "connection to : %s:%s" % (addr,port)
+print("connection to : %s:%s" % (addr,port))
 
 fn = sys.argv[1]
 cs.send(OP_NAMEOBJ_CREATE)

--- a/test/playsound.py
+++ b/test/playsound.py
@@ -20,7 +20,7 @@ s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 addr = '127.0.0.1'
 port = 65504
 cs = socket.create_connection((addr, port))
-print "connection to : %s:%s" % (addr,port)
+print("connection to : %s:%s" % (addr,port))
 
 fn = sys.argv[1]
 cs.send(OP_PLAYSOUND)


### PR DESCRIPTION
Test files use print statement instead of print(). Not super important, but making them valid python 3 syntax allows running linters/analysers on the codebase.